### PR TITLE
Implement server with streaming for both Entropix and normal Llama

### DIFF
--- a/mlx_generate.py
+++ b/mlx_generate.py
@@ -15,10 +15,7 @@ LN_2 = 0.69314718056  # ln(2)
 def generate_step(
     prompt: mx.array,
     model: nn.Module,
-    temp: float = 0.666,
-    top_p: float = 0.9,
-    top_k: int = 0,
-    prefill_step_size: int = 512,
+    prefill_step_size: int = 1024,
     max_kv_size: Optional[int] = None,
     cache_history: Optional[List[Tuple[mx.array, mx.array]]] = None,
     sampler_config: SamplerConfig = SamplerConfig(),

--- a/mlx_server.py
+++ b/mlx_server.py
@@ -1,0 +1,154 @@
+import argparse
+import json
+import logging
+from http.server import BaseHTTPRequestHandler, HTTPServer
+from pathlib import Path
+import mlx.core as mx
+from mlx_lm.utils import load as load_mlx_lm
+from mlx_lm.tokenizer_utils import load_tokenizer
+from torch.utils.data.sampler import Sampler
+from mlx_model import load_entropix_model
+from mlx_generate import generate_step as generate_step
+from mlx_lm.utils import generate_step as generate_step_mlx_lm
+from mlx_sampler import SamplerConfig
+from mlx_lm.server import APIHandler, stopping_criteria
+from mlx_lm.server import ModelProvider
+from typing import List
+
+class EntropixModelProvider(ModelProvider):
+    def __init__(self, cli_args: argparse.Namespace):
+        self.cli_args = cli_args
+        self.normal = cli_args.normal
+        self.model_path = Path(cli_args.model_path)
+        self.model = None
+        self.is_model_loaded = False
+        self.load(requested_model="default_model")
+
+    def load(self, requested_model, requested_adapter = None):
+        if requested_model != "default_model":
+            self.model_path = Path(requested_model)
+        print(f"Loading model...")
+        if self.is_model_loaded:
+            print(f"Model already loaded. Returning...")
+            return self.model, self.tokenizer
+        model_path = self.model_path
+        try:
+            logging.info(f"Loading model from {model_path}")
+            if self.normal:
+                self.model, self.tokenizer = load_mlx_lm(str(model_path))
+            else:
+                self.model = load_entropix_model(model_path)
+                self.tokenizer = load_tokenizer(model_path)
+            self.is_model_loaded = True
+            print(f"Model loaded from {model_path} successfully!")
+        except Exception as e:
+            logging.error(f"Error loading model: {e}")
+            self.is_model_loaded = False
+            raise
+
+        return self.model, self.tokenizer
+
+class EntropixAPIHandler(APIHandler):
+    def __init__(self, model_provider: ModelProvider, *args, **kwargs):
+        self.sampler_config = kwargs.pop('sampler_config', None)
+        super().__init__(model_provider, *args, **kwargs)
+        self.max_tokens = 4096
+
+    def handle_completion(self, prompt, stop_id_sequences: List[List[int]]):
+        """
+        Generate completions (non-streaming) for the given prompt
+        """
+        detokenizer = self.tokenizer.detokenizer
+        detokenizer.reset()
+
+        tokens = []
+        finish_reason = "length"
+        stop_sequence_suffix = None
+
+        logging.debug(f"Starting completion:")
+        for token, _ in zip(
+            generate_step(
+                prompt,
+                model = self.model,
+                sampler_config=self.sampler_config,
+            ),
+            range(self.max_tokens)
+        ):
+            detokenizer.add_token(token)
+            logging.debug(detokenizer.text)
+            tokens.append(token)
+
+            stop_condition = stopping_criteria(
+                tokens, stop_id_sequences, self.tokenizer.eos_token_id
+            )
+
+            if stop_condition.stop_met:
+                finish_reason = "stop"
+                if stop_condition.trim_length:
+                    stop_sequence_suffix = self.tokenizer.decode(
+                        tokens[-stop_condition.trim_length :]
+                    )
+                break
+        detokenizer.finalize()
+        text = (
+            detokenizer.text
+            if stop_sequence_suffix is None
+            else detokenizer.text[: -len(stop_sequence_suffix)]
+        )
+        response = self.generate_response(
+            text=text,
+            finish_reason=finish_reason,
+            prompt_token_count=len(prompt),
+            completion_token_count=len(tokens),
+        )
+
+        print(response)
+
+        response_json = json.dumps(response).encode()
+        indent = "\t"
+        logging.debug(f"Outgoing response: {json.dumps(response, indent = indent)}")
+
+         # Send an additional Content-Length header when it is known
+        self.send_header("Content-Length", str(len(response_json)))
+        self.end_headers()
+
+        self.wfile.write(response_json)
+        self.wfile.flush()
+
+def run_server(host, port, model_provider, normal = False):
+    server_address = (host, port)
+    sampler_config = SamplerConfig()
+    if normal:
+        handler_class = lambda *args, **kwargs: APIHandler(model_provider, *args, **kwargs)
+    else:
+        def create_handler(*args, **kwargs):
+            kwargs['sampler_config'] = sampler_config
+            return EntropixAPIHandler(model_provider, *args, **kwargs)
+
+        handler_class = create_handler
+    httpd = HTTPServer(server_address, handler_class)
+    print(f"Starting server on {host}:{port}")
+    httpd.serve_forever()
+
+def main():
+    parser = argparse.ArgumentParser(description="Run an MLX model server")
+    parser.add_argument("--model_path", type=str, default = "weights/Llama-3.2-1B-Instruct", help="Path to the model weights")
+    parser.add_argument("--normal", action="store_true", help="Use normal model for generation")
+    parser.add_argument("--host", type=str, default="localhost", help="Server host")
+    parser.add_argument("--port", type=int, default=8000, help="Server port")
+    args = parser.parse_args()
+
+    if args.normal:
+        args.model = args.model_path
+        args.trust_remote_code = False
+        args.chat_template = ""
+        args.max_tokens = 2048
+        args.adapter_path = None
+        args.use_default_chat_template = True
+        model_provider = ModelProvider(cli_args = args)
+    else:
+        model_provider = EntropixModelProvider(cli_args = args)
+    run_server(args.host, args.port, model_provider, normal = args.normal)
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
This pull request introduces significant changes to the `mlx_generate.py` and `mlx_server.py` files, focusing on modifying the generation step parameters and implementing a new server for handling model interactions. The most important changes include increasing the `prefill_step_size`, adding a new server implementation for model handling, and defining handlers for different types of model interactions.

### Changes to generation parameters:
* [`mlx_generate.py`](diffhunk://#diff-397e5d7ccac056efca3dcc7c13433e9a473155a22ffebd35290dca5597985f1eL18-R18): Increased the `prefill_step_size` from 512 to 1024 to allow for larger initial context during generation.

### New server implementation:
* [`mlx_server.py`](diffhunk://#diff-426a99a7ef3347771a6333afc3e55e35dbbdcf5e936135cea6d2552788289615R1-R220): Added a new server implementation, including imports, class definitions, and methods to handle model loading and interaction. This includes the `EntropixModelProvider` class for loading models and the `EntropixAPIHandler` class for handling API requests.

### Handlers for model interactions:
* [`mlx_server.py`](diffhunk://#diff-426a99a7ef3347771a6333afc3e55e35dbbdcf5e936135cea6d2552788289615R1-R220): Implemented `handle_completion` and `handle_stream` methods in the `EntropixAPIHandler` class to manage non-streaming and streaming completions, respectively. These methods handle token generation, detokenization, and response formatting.
* [`mlx_server.py`](diffhunk://#diff-426a99a7ef3347771a6333afc3e55e35dbbdcf5e936135cea6d2552788289615R1-R220): Defined the `run_server` function to start the HTTP server, and the `main` function to parse command-line arguments and initialize the server.